### PR TITLE
Implement METAR download helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-Trying out Codex
+# Forecaster Utilities
+
+This repository contains utilities for working with aviation weather data.
+
+## Downloading METAR Data
+
+Use `metar.download_monthly_metars` to download METAR observations for a
+specific station and month from the Iowa State IEM service.
+
+Example:
+
+```python
+from metar import download_monthly_metars
+
+df = download_monthly_metars("KDSM", 2024, 1)
+print(df.head())
+```

--- a/metar.py
+++ b/metar.py
@@ -1,0 +1,41 @@
+import calendar
+from io import StringIO
+import requests
+import pandas as pd
+
+
+def download_monthly_metars(icao: str, year: int, month: int) -> pd.DataFrame:
+    """Download a month of METAR observations from Iowa State IEM.
+
+    Parameters
+    ----------
+    icao : str
+        Four letter ICAO station identifier.
+    year : int
+        Year of desired data (UTC).
+    month : int
+        Month of desired data (1-12, UTC).
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame of METAR observations for the given month in UTC.
+    """
+    last_day = calendar.monthrange(year, month)[1]
+    params = {
+        "station": icao,
+        "data": "metars",
+        "year1": year,
+        "month1": month,
+        "day1": 1,
+        "year2": year,
+        "month2": month,
+        "day2": last_day,
+        "tz": "Etc/UTC",
+        "format": "onlycomma",
+        "latlon": "no",
+    }
+    url = "https://mesonet.agron.iastate.edu/cgi-bin/request/asos.py"
+    resp = requests.get(url, params=params, timeout=30)
+    resp.raise_for_status()
+    return pd.read_csv(StringIO(resp.text))

--- a/test_metar.py
+++ b/test_metar.py
@@ -1,0 +1,18 @@
+import pandas as pd
+from unittest import TestCase, mock
+import metar
+
+class TestDownloadMetars(TestCase):
+    def test_download_monthly_metars(self):
+        sample_csv = (
+            "station,valid,metar\n"
+            "KAAA,2024-01-01 00:00,example1\n"
+            "KAAA,2024-01-01 01:00,example2\n"
+        )
+        with mock.patch('metar.requests.get') as mget:
+            mget.return_value.status_code = 200
+            mget.return_value.text = sample_csv
+            df = metar.download_monthly_metars('KAAA', 2024, 1)
+        self.assertEqual(len(df), 2)
+        self.assertListEqual(list(df.columns), ['station', 'valid', 'metar'])
+


### PR DESCRIPTION
## Summary
- add simple README content
- implement `download_monthly_metars` function for fetching IEM data
- provide a basic unit test

## Testing
- `python3 -m unittest -v`

------
https://chatgpt.com/codex/tasks/task_e_684a0823eb4483308e5bceb1ba5e259a