### PR TITLE
Add GFS comparison helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,24 @@ from metar import download_monthly_metars
 df = download_monthly_metars("KDSM", 2024, 1)
 print(df.head())
 ```
+
+## Comparing to GFS
+
+Use `gfs_compare.compare_metar_to_gfs` to append GFS model temperature to a
+DataFrame of METAR observations. The function rounds each observation time to
+nearest hour, finds the latest GFS cycle before that time, and reads the 2 m
+temperature forecast using Herbie. The lead time can be adjusted with the
+`lead_hours` parameter (2 by default).
+
+Example:
+
+```python
+from metar import download_monthly_metars
+from gfs_compare import compare_metar_to_gfs
+
+metars = download_monthly_metars("KDSM", 2024, 1)
+metars["lat"] = 41.534
+metars["lon"] = -93.660
+comp = compare_metar_to_gfs(metars)
+print(comp[["valid", "gfs_tmp_2m"]].head())
+```

--- a/gfs_compare.py
+++ b/gfs_compare.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pandas as pd
+from herbie import Herbie
+
+
+def _get_cycle(time: pd.Timestamp) -> pd.Timestamp:
+    """Return the latest GFS cycle prior to ``time``."""
+    cycle_hour = (time.hour // 6) * 6
+    cycle = time.replace(hour=cycle_hour, minute=0, second=0, microsecond=0)
+    if cycle > time:
+        cycle -= timedelta(hours=6)
+    return cycle
+
+
+def compare_metar_to_gfs(df: pd.DataFrame, lead_hours: int = 2) -> pd.DataFrame:
+    """Append GFS 2 m temperature to a METAR DataFrame.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame with observation time in ``valid`` and station
+        coordinates in ``lat`` and ``lon``.
+    lead_hours : int, optional
+        Round the model lead time to this interval. Defaults to ``2``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The original DataFrame with an added ``gfs_tmp_2m`` column.
+    """
+    df = df.copy()
+    df["valid"] = pd.to_datetime(df["valid"])
+    df["valid_hour"] = df["valid"].dt.round("1H")
+
+    temps = []
+    for _, row in df.iterrows():
+        valid_time = row["valid_hour"]
+        cycle = _get_cycle(valid_time)
+        lead = int((valid_time - cycle).total_seconds() / 3600)
+        # Round forecast hour to requested interval
+        lead = int(round(lead / lead_hours) * lead_hours)
+
+        H = Herbie(cycle, model="gfs", fxx=lead, product="pgrb2.0p25")
+        ds = H.xarray("TMP:2 m")
+        point = ds.sel(longitude=row["lon"], latitude=row["lat"], method="nearest")
+        temps.append(point.to_array().squeeze().item())
+
+    df["gfs_tmp_2m"] = temps
+    return df


### PR DESCRIPTION
## Summary
- create `gfs_compare.py` with `compare_metar_to_gfs`
- document GFS comparison usage in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a0e8d08008330add2d12b914741dd